### PR TITLE
Fix casing issues for System.configuration and System.XML

### DIFF
--- a/build/Program.cs
+++ b/build/Program.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Xml.Linq;
 
 public static partial class Program
@@ -143,7 +144,16 @@ public static partial class Program
                     && usedFileNames.Add(Path.GetFileName(filePath))
                     && assemblyNames.Contains(Path.GetFileNameWithoutExtension(filePath)))
                 {
-                    builder.AddFiles(rootPath, source: filePath, RelativeNupkgDestination);
+                    if (HasAnyExtension(filePath, ".xml"))
+                    {
+                        builder.AddFiles(rootPath, source: filePath, RelativeNupkgDestination);
+                    }
+                    else
+                    {
+                        var name = AssemblyName.GetAssemblyName(filePath).Name + Path.GetExtension(filePath);
+
+                        builder.AddFiles(rootPath, source: filePath, Path.Combine(RelativeNupkgDestination, name));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #3

This is a minor change to fix System.configuration and System.XML casing to System.Configuration and System.XML.

This odd casing is present in older versions of dotnet framework and cause problems when trying to build net35 projects using this nuget on linux. dotnet on Linux cannot resolve assemblies when the dll casing is not consistent with the assembly name.
